### PR TITLE
Change OSC 'b' (Blob) encoding to parse, and produce strings of bytes.

### DIFF
--- a/lib/Protocol/OSC.pm
+++ b/lib/Protocol/OSC.pm
@@ -6,7 +6,7 @@ package Protocol::OSC;
 
 use Scalar::Util 'looks_like_number';
 use constant { NTP_EPOCH_DIFF => 2208988800, MAX_INT => 2**32 };
-my %converter = qw(i N f N s Z*x!4 b N/C*x!4 h h t N2);
+my %converter = qw(i N f N s Z*x!4 b N/a*x!4 h h t N2);
 my %filter = (f => [qw'f L']);
 if (pack('f>', 0.5) eq pack N => unpack L => pack f => 0.5) { # f> is ieee754 compatible
     delete$filter{f}; $converter{f} = 'f>' }

--- a/t/parse.t
+++ b/t/parse.t
@@ -12,6 +12,9 @@ my @tests = (
     ['pattern i1i1' => "/test\x00\x00\x00".",ii\x00"."\x00\x00\x00\x01"."\x00\x00\x00\x01" => ['/test','ii',1,1]],
     ['pattern s0s0' => "/test\x00\x00\x00".",ss\x00"."\x00\x00\x00\x00"."\x00\x00\x00\x00" => ['/test','ss','','']],
     ['pattern f0f0' => "/test\x00\x00\x00".",ff\x00"."\x00\x00\x00\x00"."\x00\x00\x00\x00" => ['/test','ff',0,0]],
+    ['pattern b0b0' => "/test\x00\x00\x00".",bb\x00"."\x00\x00\x00\x00"."\x00\x00\x00\x00" => ['/test','bb','','']],
+    ['pattern b0b%' => "/test\x00\x00\x00".",bb\x00"."\x00\x00\x00\x00"."\x00\x00\x00\x01"."\x25\x00\x00\x00" => ['/test','bb','','%']], 
+    ['pattern b%b0' => "/test\x00\x00\x00".",bb\x00"."\x00\x00\x00\x01"."\x25\x00\x00\x00"."\x00\x00\x00\x00" => ['/test','bb','%','']],
 );
 
 my $osc = Protocol::OSC->new;


### PR DESCRIPTION
Previously 'b' would only encode single numbers 0..255, and decode
Blob fields as lists of numbers 0..255, collapsed into the list of
arguments, so a non-terminal 'b' value could not be determined
easily.  The C* pack required multiple arguments to correctly pack
a stream of bytes greater than 1, replacing 'C' with 'a' in the b
pack/unpack option allows parse and message to work with bytestrings.